### PR TITLE
AND operator takes precedence over OR, both are left associative

### DIFF
--- a/src/ExpressionFactory.php
+++ b/src/ExpressionFactory.php
@@ -38,61 +38,61 @@ class ExpressionFactory
             }));
 
         // Provide the default mathematical operators.
-        $this->addOperator(new Operator('\+', 4, Operator::LEFT_ASSOCIATIVE, 2,
+        $this->addOperator(new Operator('\+', 5, Operator::LEFT_ASSOCIATIVE, 2,
             function($values) {
                 return $this->math->add($values[0], $values[1]);
             }))
-          ->addOperator(new Operator('\-', 4, Operator::LEFT_ASSOCIATIVE, 2,
+          ->addOperator(new Operator('\-', 5, Operator::LEFT_ASSOCIATIVE, 2,
             function($values) {
                 return $this->math->subtract($values[0], $values[1]);
             }))
-          ->addOperator(new Operator('\*', 5, Operator::LEFT_ASSOCIATIVE, 2,
+          ->addOperator(new Operator('\*', 6, Operator::LEFT_ASSOCIATIVE, 2,
             function($values) {
                 return $this->math->multiply($values[0], $values[1]);
             }))
-          ->addOperator(new Operator('\/', 5, Operator::LEFT_ASSOCIATIVE, 2,
+          ->addOperator(new Operator('\/', 6, Operator::LEFT_ASSOCIATIVE, 2,
             function($values) {
                 return $this->math->divide($values[0], $values[1]);
             }))
-          ->addOperator(new Operator('\%', 5, Operator::LEFT_ASSOCIATIVE, 2,
+          ->addOperator(new Operator('\%', 6, Operator::LEFT_ASSOCIATIVE, 2,
             function($values) {
                 return $this->math->modulus($values[0], $values[1]);
             }));
 
         // Provide the default comparison operators.
         $this
-          ->addOperator(new Operator('==', 3, Operator::LEFT_ASSOCIATIVE, 2,
+          ->addOperator(new Operator('==', 4, Operator::LEFT_ASSOCIATIVE, 2,
             function($values) {
                 return (int)($this->math->compare($values[0], $values[1]) === 0);
             }))
-          ->addOperator(new Operator('!=', 3, Operator::LEFT_ASSOCIATIVE, 2,
+          ->addOperator(new Operator('!=', 4, Operator::LEFT_ASSOCIATIVE, 2,
             function($values) {
                 return (int)($this->math->compare($values[0], $values[1]) !== 0);
             }))
-          ->addOperator(new Operator('<', 3, Operator::LEFT_ASSOCIATIVE, 2,
+          ->addOperator(new Operator('<', 4, Operator::LEFT_ASSOCIATIVE, 2,
             function($values) {
                 return (int)($this->math->compare($values[0], $values[1]) < 0);
             }))
-          ->addOperator(new Operator('<=', 3, Operator::LEFT_ASSOCIATIVE, 2,
+          ->addOperator(new Operator('<=', 4, Operator::LEFT_ASSOCIATIVE, 2,
             function($values) {
                 return (int)($this->math->compare($values[0], $values[1]) <= 0);
             }))
-          ->addOperator(new Operator('>', 3, Operator::LEFT_ASSOCIATIVE, 2,
+          ->addOperator(new Operator('>', 4, Operator::LEFT_ASSOCIATIVE, 2,
             function($values) {
                 return (int)($this->math->compare($values[0], $values[1]) > 0);
             }))
-          ->addOperator(new Operator('>=', 3, Operator::LEFT_ASSOCIATIVE, 2,
+          ->addOperator(new Operator('>=', 4, Operator::LEFT_ASSOCIATIVE, 2,
             function($values) {
                 return (int)($this->math->compare($values[0], $values[1]) >= 0);
             }));
 
         // Provide basic logic operators.
         $this
-          ->addOperator(new Operator('AND', 2, Operator::NONE_ASSOCIATIVE, 2,
+          ->addOperator(new Operator('AND', 3, Operator::LEFT_ASSOCIATIVE, 2,
             function($values) {
                 return (int)($this->math->native($values[0]) && $this->math->native($values[1]));
             }))
-          ->addOperator(new Operator('OR', 2, Operator::NONE_ASSOCIATIVE, 2,
+          ->addOperator(new Operator('OR', 2, Operator::LEFT_ASSOCIATIVE, 2,
             function($values) {
                 return (int)($this->math->native($values[0]) || $this->math->native($values[1]));
             }))

--- a/tests/EvaluatorTest.php
+++ b/tests/EvaluatorTest.php
@@ -127,4 +127,18 @@ class EvaluatorTest extends TestCase
         $result = $this->evaluator->evaluate($tokens, $this->context);
     }
 
+    /**
+     * Test that AND operator takes precedence over OR
+     *
+     * @return void
+     */
+    public function testBooleanOperatorsPrecedence()
+    {
+        $tokens = $this->parser->parse('0 AND 0 OR 1 AND 1 OR 1 AND 0');
+
+        $result = $this->evaluator->evaluate($tokens, $this->context);
+
+        $this->assertEquals($result, '1');
+    }
+
 }


### PR DESCRIPTION
Hi

I encountered an unexpected result with boolean expressions.

Here is the faulty expression

```0 AND 0 OR 0 AND 0 OR 1 AND 1 OR 1 AND 0```

It should return 1, but it actually returns 0

```php
      $math = new BcMath();
      $factory = new ExpressionFactory($math);
      $lexer = new Lexer($factory);
      $parser = new Parser($lexer);
      $evaluator = new Evaluator();
      $context = new Context();

      $tokens = $parser->parse("0 AND 0 OR 0 AND 0 OR 1 AND 1 OR 1 AND 0");
      echo $evaluator->evaluate($tokens, $context);
```

It appears that the library does not takes into account operator precedence of boolean operators.

Here is a fix proposal.

For reference about associativity of OR and AND operators : https://www.php.net/manual/en/language.operators.precedence.php

