### PR TITLE
Added scale to bcmath class (defaults to 0 for backwards compatibility)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
   "keywords": ["expression evaluator","math parser", "shunting-yard algorithm", "math calculator"],
   "homepage": "https://github.com/xylemical/php-expressions",
   "require": {
-    "php": ">=7.0.0"
+    "php": ">=7.1.0|>=8.0",
+    "ext-bcmath": "*"
   },
   "autoload": {
     "psr-4": {
@@ -19,6 +20,6 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0"
+    "phpunit/phpunit": "^7.0|^8.0"
   }
 }

--- a/src/Math/BcMath.php
+++ b/src/Math/BcMath.php
@@ -16,31 +16,41 @@ use Xylemical\Expressions\MathInterface;
 class BcMath implements MathInterface
 {
     /**
-     * {@inheritdoc}
+     * @var int
      */
-    public function add($a, $b, $decimals = 0) {
-        return bcadd($a, $b, $decimals);
+    protected $scale = 0;
+
+    public function __construct($scale = 0)
+    {
+        $this->scale = (int)$scale;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function subtract($a, $b, $decimals = 0) {
-        return bcsub($a, $b, $decimals);
+    public function add($a, $b, $scale = null) {
+        return bcadd($a, $b, $scale ?? $this->scale);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function multiply($a, $b, $decimals = 0) {
-        return bcmul($a, $b, $decimals);
+    public function subtract($a, $b, $scale = null) {
+        return bcsub($a, $b, $scale ?? $this->scale);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function divide($a, $b, $decimals = 0) {
-        return bcdiv($a, $b, $decimals);
+    public function multiply($a, $b, $scale = null) {
+        return bcmul($a, $b, $scale ?? $this->scale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function divide($a, $b, $scale = null) {
+        return bcdiv($a, $b, $scale ?? $this->scale);
     }
 
     /**
@@ -53,8 +63,8 @@ class BcMath implements MathInterface
     /**
      * {@inheritdoc}
      */
-    public function compare($a, $b, $decimals = 0) {
-        return bccomp($a, $b, $decimals);
+    public function compare($a, $b, $scale = null) {
+        return bccomp($a, $b, $scale ?? $this->scale);
     }
 
     /**

--- a/src/MathInterface.php
+++ b/src/MathInterface.php
@@ -19,42 +19,42 @@ interface MathInterface
      *
      * @param string $a
      * @param string $b
-     * @param int $decimals
+     * @param int $scale
      *
      * @return string
      */
-    public function add($a, $b, $decimals = 0);
+    public function add($a, $b, $scale = 0);
 
     /**
      * Subtract $b from $a.
      *
      * @param string $a
      * @param string $b
-     * @param int $decimals
+     * @param int $scale
      *
      * @return string
      */
-    public function subtract($a, $b, $decimals = 0);
+    public function subtract($a, $b, $scale = 0);
 
     /**
      * @param string $a
      * @param string $b
-     * @param int $decimals
+     * @param int $scale
      *
      * @return string
      */
-    public function multiply($a, $b, $decimals = 0);
+    public function multiply($a, $b, $scale = 0);
 
     /**
      * Divide $a by $b.
      *
      * @param string $a
      * @param string $b
-     * @param int $decimals
+     * @param int $scale
      *
      * @return string
      */
-    public function divide($a, $b, $decimals = 0);
+    public function divide($a, $b, $scale = 0);
 
     /**
      * Get the modulus of $a from $b.
@@ -71,11 +71,11 @@ interface MathInterface
      *
      * @param string $a
      * @param string $b
-     * @param int $decimals
+     * @param int $scale
      *
      * @return int
      */
-    public function compare($a, $b, $decimals = 0);
+    public function compare($a, $b, $scale = 0);
 
     /**
      * Gets the PHP native version of the value.

--- a/tests/EvaluatorTest.php
+++ b/tests/EvaluatorTest.php
@@ -28,7 +28,7 @@ class EvaluatorTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
 
         $math = new BcMath();

--- a/tests/ExpressionFactoryTest.php
+++ b/tests/ExpressionFactoryTest.php
@@ -28,7 +28,7 @@ class ExpressionFactoryTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -348,5 +348,54 @@ class ExpressionFactoryTest extends TestCase
         $result = $this->evaluator->evaluate($tokens, $this->context);
 
         $this->assertEquals('2', $result);
+    }
+
+    /**
+     * @dataProvider getScaleTestData
+     */
+    public function testScalePropertyIsApplied($scale, $expression, $expected)
+    {
+        $math = new BcMath($scale);
+        $factory = new ExpressionFactory($math);
+
+        $lexer = new Lexer($factory);;
+        $parser = new Parser($lexer);
+
+        $tokens = $parser->parse($expression);
+
+        $result = $this->evaluator->evaluate($tokens, $this->context);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function getScaleTestData()
+    {
+        return [
+            'multiplication' => [
+                'scale' => 3,
+                'expression' => '1.005 * 2',
+                'expected' => '2.010',
+            ],
+            'division' => [
+                'scale' => 4,
+                'expression' => '1.005 / 2',
+                'expected' => '0.5025',
+            ],
+            'division with reduced scale' => [
+                'scale' => 3,
+                'expression' => '1.005 / 2',
+                'expected' => '0.502',
+            ],
+            'addition' => [
+                'scale' => 5,
+                'expression' => '1.005 + 2',
+                'expected' => '3.00500',
+            ],
+            'subtraction' => [
+                'scale' => 3,
+                'expression' => '1.005 - 2',
+                'expected' => '-0.995',
+            ],
+        ];
     }
 }

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -19,7 +19,7 @@ class LexerTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
 
         $math = new BcMath();
@@ -27,7 +27,7 @@ class LexerTest extends TestCase
 
         // Add in variable processor for lexing.
         $factory->addOperator(new Value('\$[a-zA-Z_][a-zA-Z0-9_]*', function(array $operands, Context $context, Token $token) {
-            return $context->getVariable(substr($token, 1));
+            return $context->getVariable(substr($token->getValue(), 1));
         }));
 
         $this->lexer = new Lexer($factory);

--- a/tests/Math/BcMathTest.php
+++ b/tests/Math/BcMathTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Xylemical\Expressions\Math;
+
+use PHPUnit\Framework\TestCase;
+
+class BcMathTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->math = new BcMath(4); // setting a default scale of 4 for these tests
+    }
+
+    public function testMultiply()
+    {
+        $this->assertEquals('0.4000', $this->math->multiply('0.1', '4'));
+    }
+
+    public function testMultiplyWithOverriddenScale()
+    {
+        $this->assertEquals('0.4000000000', $this->math->multiply('0.1', '4', 10));
+    }
+
+    public function testSubtract()
+    {
+        $this->assertEquals('-3.9000', $this->math->subtract('0.1', '4'));
+    }
+
+    public function testSubtractWithOverriddenScale()
+    {
+        $this->assertEquals('-3.9', $this->math->subtract('0.1', '4', 1));
+    }
+
+    public function testCompare()
+    {
+        $this->assertEquals('0', $this->math->compare('4.000', '4'));
+        $this->assertEquals('-1', $this->math->compare('0.399', '4'));
+        $this->assertEquals('1', $this->math->compare('4.001', '4.000'));
+    }
+
+    public function testNative()
+    {
+        $this->assertEquals(0, $this->math->native('0.00'));
+        $this->assertEquals(1, $this->math->native('1'));
+        $this->assertEquals(1.0, $this->math->native('1.00'));
+    }
+
+    public function testDivide()
+    {
+        $this->assertEquals('0.0325', $this->math->divide('0.13', '4'));
+    }
+
+    public function testDivideWithOverriddenScale()
+    {
+        $this->assertEquals('0.03', $this->math->divide('0.13', '4', 2));
+    }
+
+    public function testAdd()
+    {
+        $this->assertEquals('4.1000', $this->math->add('0.1', '4'));
+    }
+    public function testAddWithOverriddenScale()
+    {
+        $this->assertEquals('4', $this->math->add('0.1', '4', 0));
+    }
+
+    public function testModulus()
+    {
+        $this->assertEquals('1', $this->math->modulus('5', '4'));
+    }
+}

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -19,7 +19,7 @@ class ParserTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
 
         $math = new BcMath();
@@ -27,7 +27,7 @@ class ParserTest extends TestCase
 
         // Add in variable processor for lexing.
         $factory->addOperator(new Value('\$[a-zA-Z_][a-zA-Z0-9_]*', function(array $operands, Context $context, Token $token) {
-            return $context->getVariable(substr($token, 1));
+            return $context->getVariable(substr($token->getValue(), 1));
         }));
 
         $lexer = new Lexer($factory);;


### PR DESCRIPTION
The primary purpose of this PR is to allow bcmath scale to be specified

1. Added BcMathTest to ensure base methods function as expected
2. Updated composer.json to allow testing in PHP8.x
3. Changed MathInterface $decimals param to $scale for consistency
4. Updated minimum PHP version to 7.1 so that tests will work in higher versions also (void return compatibility)
5. Fixes ParserTest and LexerTest setup method to use the value of the token instead of the token object in substr call